### PR TITLE
feat(client): Leave radio on player downed

### DIFF
--- a/client/event.lua
+++ b/client/event.lua
@@ -250,6 +250,9 @@ RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
         Wait(1000)
         Radio:doRadioCheck(val.items)
         Radio.PlayerDead = val.metadata.isdead or val.metadata.inlaststand
+        if Radio.PlayerDead then
+            Radio:LeaveOnDeath()
+        end
     end
 end)
 
@@ -263,10 +266,6 @@ RegisterNetEvent("QBCore:Client:SetDuty", function(newDuty)
     Radio.PlayerDuty = newDuty
 end)
 
-RegisterNetEvent("ND:updateCharacter", function(character)
-    Radio.PlayerDead = character.metadata.dead
-end)
-
 AddEventHandler('ox_inventory:updateInventory', function()
     Radio:doRadioCheck()
 end)
@@ -278,13 +277,15 @@ AddEventHandler('gameEventTriggered', function(event, data)
             if Radio.usingRadio then
                 TriggerEvent('mm_radio:client:remove')
             end
-            if Radio.playerLoaded and Radio.onRadio and Radio.hasRadio and Radio.RadioChannel ~= 0 then
-                Radio:leaveradio()
-            end
         end
     end
 end)
 
-AddStateBagChangeHandler('dead', ('player:%s'):format(cache.serverId), function(_, _, value)
-    Radio.PlayerDead = value
+-- Checking this statebag instead of "isDead" so we can also catch the "last stand" state
+AddStateBagChangeHandler('qbx_medical:deathState', ('player:%s'):format(cache.serverId), function(_, _, value)
+    local isDead = value ~= 1 and true or false
+    Radio.PlayerDead = isDead
+    if value then
+        Radio:LeaveOnDeath()
+    end
 end)

--- a/client/function.lua
+++ b/client/function.lua
@@ -335,6 +335,16 @@ function Radio:UpdateJammerRemove(id)
     end
 end
 
+function Radio:LeaveOnDeath()
+    if not self.PlayerDead then return end
+    if not Shared.LeaveOnDeath then return end
+    if not self.playerLoaded then return end
+    if not self.hasRadio then return end
+    if not self.onRadio then return end
+    if self.RadioChannel == 0 then return end
+    self:leaveradio()
+end
+
 function UpdateTime()
     CreateThread(function()
         while Radio.usingRadio do

--- a/shared/shared.lua
+++ b/shared/shared.lua
@@ -1,6 +1,9 @@
 ---@type number
 Shared.MaxFrequency = 500.00 -- Max Limit of Radio Channel
 
+---@type boolean
+Shared.LeaveOnDeath = true -- Should the player leave the radio channel when they die
+
 ---@class Jammer
 ---@field state boolean
 ---@field model string
@@ -10,10 +13,10 @@ Shared.MaxFrequency = 500.00 -- Max Limit of Radio Channel
 
 ---@type Jammer
 Shared.Jammer = {
-    state = false, -- to use jammer system or not 
+    state = false, -- to use jammer system or not
     model = 'sm_prop_smug_jammer', -- prop to spawn for jammer
     permission = {"police"}, -- permission how can setup jammer (job/gang)
-    default = {}, -- default jammer setup location 
+    default = {}, -- default jammer setup location
     range = {
         min = 10.0,
         max = 100.0,


### PR DESCRIPTION
## Description

- Uses the qbox specific states to leave the radio when the medical state changes to `LAST_STAND` or `DEAD`
- Added a config option for servers that dont want this feature

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
