### PR TITLE
feat: add pt-br translation

### DIFF
--- a/locales/pt-br.json
+++ b/locales/pt-br.json
@@ -1,0 +1,34 @@
+{
+  "join_notify_description": "Conectado à Estação %.2f MHz",
+  "invalid_notify_description": "Estação %.2f MHz não está disponível",
+  "already_notify_description": "Você já está conectado à Estação %.2f MHz",
+  "restricted_notify_description": "Você não tem permissão para entrar na Estação %.2f MHz",
+  "volume_notify_description": "Volume ajustado para %d%%",
+  "unsuccess_name": "Falha ao alterar o nome",
+  "jammer_notify_description": "Falha ao conectar à Estação %.2f MHz",
+  "toggle_defean": "Rádio Silenciado",
+  "toggle_undeafen": "Rádio Ativado",
+  "failed_mute": "Falha ao silenciar o jogador",
+
+  "ui": {
+    "header": "NO RÁDIO",
+    "frequency": "Frequência",
+    "disconnect": "DESCONECTAR",
+    "notconnected": "DESCONECTADO",
+    "settings": "Configurações",
+    "channels": "Canais",
+    "radio": "Rádio",
+    "members": "Membros",
+    "favorites": "Favoritos",
+    "recommended": "Recomendado",
+    "clear": "LIMPAR",
+    "hide_overlay": "OCULTAR SOBREPOSIÇÃO",
+    "show_overlay": "MOSTRAR SOBREPOSIÇÃO",
+    "save": "SALVAR",
+    "radio_settings": "Configurações do Rádio",
+    "move_radio": "Mover Rádio",
+    "allow_move": "Permitir Mover",
+    "overlay_settings": "Configurações da Sobreposição",
+    "enableClicks": "Som do Rádio"
+  }
+}


### PR DESCRIPTION
## Description

Adds support for **Brazilian Portuguese (pt-BR)** localization in the radio system.  
Includes the `pt-br.json` file with full translations for the user interface and notification messages.  
This is useful for Brazilian communities running Qbox-based servers.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
