### PR TITLE
feat: Added configurable ranges to radio

### DIFF
--- a/client/event.lua
+++ b/client/event.lua
@@ -209,18 +209,34 @@ RegisterNetEvent("mm_radio:client:recharge", function()
 end)
 
 RegisterNetEvent("pma-voice:radioActive", function(talkingState)
-    Radio:SendSvelteMessage("updateRadioTalking", {
-        radioId = tostring(Radio.playerServerID),
-        radioTalking = talkingState
-    })
+    if Radio.radioData and Radio.radioData[tostring(source)] then
+        Radio:SendSvelteMessage("updateRadioTalking", {
+            radioId = tostring(source),
+            radioTalking = talkingState
+        })
+    end
 end)
 
 RegisterNetEvent("pma-voice:setTalkingOnRadio", function(source, talkingState)
-    Radio:SendSvelteMessage("updateRadioTalking", {
-        radioId = tostring(source),
-        radioTalking = talkingState
-    })
+    if Radio.radioData and Radio.radioData[tostring(source)] then
+        Radio:SendSvelteMessage("updateRadioTalking", {
+            radioId = tostring(source),
+            radioTalking = talkingState
+        })
+    end
+
+    if not Shared.UseRanges then return end
+    local plyState = LocalPlayer.state
+    local radioCh = plyState.radioChannel or 0
+    print(('pma-voice:setTalkingOnRadio: %s, %s, %s'):format(source, talkingState, radioCh))
+    if talkingState and radioCh < Shared.MaxFrequency then
+        print(('pma-voice:setTalkingOnRadio: StartSubmixLoop %s'):format(source))
+        Radio:StartSubmixLoop(source)
+    else
+        Radio:StopSubmix(source)
+    end
 end)
+
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     Radio.playerLoaded = true

--- a/client/event.lua
+++ b/client/event.lua
@@ -228,9 +228,8 @@ RegisterNetEvent("pma-voice:setTalkingOnRadio", function(source, talkingState)
     if not Shared.UseRanges then return end
     local plyState = LocalPlayer.state
     local radioCh = plyState.radioChannel or 0
-    print(('pma-voice:setTalkingOnRadio: %s, %s, %s'):format(source, talkingState, radioCh))
+
     if talkingState and radioCh < Shared.MaxFrequency then
-        print(('pma-voice:setTalkingOnRadio: StartSubmixLoop %s'):format(source))
         Radio:StartSubmixLoop(source)
     else
         Radio:StopSubmix(source)

--- a/client/function.lua
+++ b/client/function.lua
@@ -117,7 +117,6 @@ function Radio:InitSubmixes()
             v.channel6Volume or 1.0
         )
         AddAudioSubmixOutput(id, 0)
-        print('Created submix:', i, 'with ID:', id , 'for range:', filter.ranges and filter.ranges.min or 'N/A', '-', filter.ranges and filter.ranges.max or 'N/A')
     end
 end
 
@@ -138,7 +137,6 @@ local function getSubmixByDistance(serverId)
     local myCoords = GetEntityCoords(PlayerPedId())
     local theirCoords = GetPlayerCoords(serverId)
     local dist = #(myCoords - theirCoords)
-    print(myCoords, theirCoords, 'Distance to serverId:', serverId, 'is', dist)
     local submix = default
     local mute = false
 
@@ -167,8 +165,7 @@ function Radio:StartSubmixLoop(serverId)
             local ped = GetPlayerPed(GetPlayerFromServerId(serverId))
             if not DoesEntityExist(ped) then break end
 
-            local submix, mute= getSubmixByDistance(serverId)
-            print('Setting submix for serverId:', serverId, 'to submix:', submix, 'mute:', mute)
+            local submix, mute = getSubmixByDistance(serverId)
             MumbleSetSubmixForServerId(serverId, submix)
             MumbleSetVolumeOverrideByServerId(serverId, mute and 0.0 or (Radio.Volume / 100))
 
@@ -183,7 +180,6 @@ function Radio:StartSubmixLoop(serverId)
 end
 
 function Radio:StopSubmix(serverId)
-    print('Stopping submix for serverId:', serverId)
     playerTalking[serverId] = false
     MumbleSetSubmixForServerId(serverId, -1)
     MumbleSetVolumeOverrideByServerId(serverId, -1.0)

--- a/client/function.lua
+++ b/client/function.lua
@@ -1,4 +1,9 @@
 local insideJammer = false
+local submixes = {}
+local default = nil
+local jammer = nil
+local maxRange = 0
+local playerTalking = {}
 
 function IsJammerAllowed(id, channel)
     for i=1, #Radio.jammer do
@@ -67,6 +72,124 @@ function Radio:SetDefaultData(cid)
     SetResourceKvp('radioSettings2', json.encode(self.userData))
 end
 
+function Radio:InitSubmixes()
+    default = CreateAudioSubmix('Radio_Default')
+    SetAudioSubmixEffectRadioFx(default, 0)
+    SetAudioSubmixEffectParamInt(default, 0, `default`, 1)
+
+    for _, effect in pairs(Shared.DefaultRadioFilter.effect) do
+        SetAudioSubmixEffectParamFloat(default, 0, GetHashKey(effect.name), effect.value)
+    end
+
+    local v = Shared.DefaultRadioFilter.volume
+    SetAudioSubmixOutputVolumes(default, 0,
+        v.frontLeftVolume or 0.75,
+        v.frontRightVolume or 1.0,
+        v.rearLeftVolume or 0.0,
+        v.rearRightVolume or 0.0,
+        v.channel5Volume or 1.0,
+        v.channel6Volume or 1.0
+    )
+    AddAudioSubmixOutput(default, 0)
+
+    for i, filter in ipairs(Shared.Ranges) do
+        local id = CreateAudioSubmix('Radio_Range_' .. i)
+        submixes[i] = { id = id, effect = filter }
+
+        if filter.ranges and filter.ranges.max > maxRange then
+            maxRange = filter.ranges.max
+        end
+
+        SetAudioSubmixEffectRadioFx(id, 0)
+        SetAudioSubmixEffectParamInt(id, 0, `default`, 1)
+
+        for _, e in pairs(filter.effect or {}) do
+            SetAudioSubmixEffectParamFloat(id, 0, GetHashKey(e.name), e.value)
+        end
+
+        local v = filter.volume or {}
+        SetAudioSubmixOutputVolumes(id, 0,
+            v.frontLeftVolume or 0.25,
+            v.frontRightVolume or 1.0,
+            v.rearLeftVolume or 0.0,
+            v.rearRightVolume or 0.0,
+            v.channel5Volume or 1.0,
+            v.channel6Volume or 1.0
+        )
+        AddAudioSubmixOutput(id, 0)
+        print('Created submix:', i, 'with ID:', id , 'for range:', filter.ranges and filter.ranges.min or 'N/A', '-', filter.ranges and filter.ranges.max or 'N/A')
+    end
+end
+
+function GetPlayerCoords(netId)
+    local player = GetPlayerFromServerId(netId)
+
+    if player ~= -1 then
+        return GetEntityCoords(GetPlayerPed(player))
+    end
+
+    local coords = lib.callback.await('mm_radio:server:coords', false, netId)
+
+    return coords
+end
+
+
+local function getSubmixByDistance(serverId)
+    local myCoords = GetEntityCoords(PlayerPedId())
+    local theirCoords = GetPlayerCoords(serverId)
+    local dist = #(myCoords - theirCoords)
+    print(myCoords, theirCoords, 'Distance to serverId:', serverId, 'is', dist)
+    local submix = default
+    local mute = false
+
+    for _, smx in pairs(submixes) do
+        local r = smx.effect.ranges
+        if r and dist > r.min and dist < r.max then
+            submix = smx.id
+            mute = r.mute or false
+            break
+        end
+    end
+
+    if dist >= maxRange then
+        mute = true
+    end
+
+    return submix, mute
+end
+
+function Radio:StartSubmixLoop(serverId)
+    if playerTalking[serverId] then return end
+    playerTalking[serverId] = true
+
+    CreateThread(function()
+        while playerTalking[serverId] do
+            local ped = GetPlayerPed(GetPlayerFromServerId(serverId))
+            if not DoesEntityExist(ped) then break end
+
+            local submix, mute= getSubmixByDistance(serverId)
+            print('Setting submix for serverId:', serverId, 'to submix:', submix, 'mute:', mute)
+            MumbleSetSubmixForServerId(serverId, submix)
+            MumbleSetVolumeOverrideByServerId(serverId, mute and 0.0 or (Radio.Volume / 100))
+
+            Wait(500)
+        end
+
+        -- Cleanup
+        MumbleSetSubmixForServerId(serverId, -1)
+        MumbleSetVolumeOverrideByServerId(serverId, -1.0)
+        playerTalking[serverId] = nil
+    end)
+end
+
+function Radio:StopSubmix(serverId)
+    print('Stopping submix for serverId:', serverId)
+    playerTalking[serverId] = false
+    MumbleSetSubmixForServerId(serverId, -1)
+    MumbleSetVolumeOverrideByServerId(serverId, -1.0)
+end
+
+
 function Radio:Init(data)
     local player = data or QBX.PlayerData
     self.identifier = player.cid
@@ -95,6 +218,8 @@ function Radio:Init(data)
     end
 
     self:doRadioCheck()
+    self:InitSubmixes()
+
 end
 
 function Radio:connecttoradio(channel)

--- a/client/nui.lua
+++ b/client/nui.lua
@@ -137,6 +137,5 @@ RegisterNUICallback('togglemutePlayer', function(data, cb)
     end
     exports['pma-voice']:toggleMutePlayer(data)
     Wait(100)
-    print(json.encode(exports['pma-voice']:getMutedPlayers()))
     cb(exports['pma-voice']:getMutedPlayers())
 end)

--- a/server/main.lua
+++ b/server/main.lua
@@ -222,6 +222,17 @@ lib.callback.register('mm_radio:server:getjammer', function()
     return jammer
 end)
 
+lib.callback.register('mm_radio:server:coords', function(source, netId)
+    local ped = GetPlayerPed(netId)
+
+    if not ped then
+        return vector3(0, 0, 0)
+    end
+
+    return GetEntityCoords(ped)
+end)
+
+
 if Shared.UseCommand then
     if not Shared.Ready then return end
     lib.addCommand('radio', {

--- a/shared/shared.lua
+++ b/shared/shared.lua
@@ -124,4 +124,116 @@ Shared.RestrictedChannels = {
     },
 }
 
+Shared.UseRanges = true 
+
+Shared.DefaultRadioFilter = {
+    effect = {
+        { name = "freq_low", value = 300.0 },
+        { name = "freq_hi", value = 5000.0 },
+        { name = "rm_mod_freq", value = 400.0 },
+        { name = "rm_mix", value = 0.1 },
+        { name = "fudge", value = 2.0 },
+        { name = "o_freq_lo", value = 300.0 },
+        { name = "o_freq_hi", value = 5000.0 },
+    },
+    volume = {
+        frontLeftVolume = 0.25,
+        frontRightVolume = 1.0,
+        rearLeftVolume = 0.0,
+        rearRightVolume = 0.0,
+        channel5Volume = 1.0,
+        channel6Volume = 1.0
+    }
+}
+
+Shared.Ranges = {
+    {
+        ranges = { min = 900.0, max = 1400.0 },
+        effect = {
+            { name = "freq_low", value = 300.0 },
+            { name = "freq_hi", value = 5000.0 },
+            { name = "rm_mod_freq", value = 300.0 },
+            { name = "rm_mix", value = 0.25 }, -- subtle modulation
+            { name = "fudge", value = 5.0 },   -- light distortion
+            { name = "o_freq_lo", value = 300.0 },
+            { name = "o_freq_hi", value = 5000.0 },
+        },
+        volume = {
+            frontLeftVolume = 0.25,
+            frontRightVolume = 0.8,
+            rearLeftVolume = 0.0,
+            rearRightVolume = 0.0,
+            channel5Volume = 0.9,
+            channel6Volume = 0.9
+        }
+    },
+    {
+        ranges = { min = 1400.0, max = 1900.0 },
+        effect = {
+            { name = "freq_low", value = 250.0 },
+            { name = "freq_hi", value = 4800.0 },
+            { name = "rm_mod_freq", value = 300.0 },
+            { name = "rm_mix", value = 0.4 },
+            { name = "fudge", value = 10.0 },
+            { name = "o_freq_lo", value = 300.0 },
+            { name = "o_freq_hi", value = 5000.0 },
+        },
+        volume = {
+            frontLeftVolume = 0.2,
+            frontRightVolume = 0.6,
+            rearLeftVolume = 0.0,
+            rearRightVolume = 0.0,
+            channel5Volume = 0.7,
+            channel6Volume = 0.7
+        }
+    },
+    {
+        ranges = { min = 1900.0, max = 2500.0 },
+        effect = {
+            { name = "freq_low", value = 200.0 },
+            { name = "freq_hi", value = 4000.0 },
+            { name = "rm_mod_freq", value = 350.0 },
+            { name = "rm_mix", value = 0.65 },
+            { name = "fudge", value = 18.0 },
+            { name = "o_freq_lo", value = 300.0 },
+            { name = "o_freq_hi", value = 5000.0 },
+        },
+        volume = {
+            frontLeftVolume = 0.15,
+            frontRightVolume = 0.4,
+            rearLeftVolume = 0.0,
+            rearRightVolume = 0.0,
+            channel5Volume = 0.6,
+            channel6Volume = 0.6
+        }
+    },
+    {
+        ranges = { min = 2500.0, max = 2700.0 },
+        effect = {
+            { name = "freq_low", value = 150.0 },
+            { name = "freq_hi", value = 3500.0 },
+            { name = "rm_mod_freq", value = 400.0 },
+            { name = "rm_mix", value = 0.85 },
+            { name = "fudge", value = 30.0 },
+            { name = "o_freq_lo", value = 300.0 },
+            { name = "o_freq_hi", value = 5000.0 },
+        },
+        volume = {
+            frontLeftVolume = 0.05,
+            frontRightVolume = 0.1,
+            rearLeftVolume = 0.0,
+            rearRightVolume = 0.0,
+            channel5Volume = 0.3,
+            channel6Volume = 0.3
+        }
+    },
+    {
+        ranges = { min = 2700.0, max = 9999.0 },
+        mute = true,
+        effect = {}, -- no need
+        volume = {}
+    }
+}
+
+
 lib.locale()


### PR DESCRIPTION
## Description

- Uses configurable ranges to make radio channels only work for players on set radius.

## Checklist

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
