### PR TITLE
Fix variable scope for radio ID assignment

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -206,8 +206,8 @@ lib.callback.register('mm_radio:server:getradiodata', function(source, slot)
         slotid = slot.slot
     end
     local slotData = exports.ox_inventory:GetSlot(source, slotid)
+	local id = false
     if slotData and lib.table.contains(Shared.RadioItem, slotData.name) then
-        local id = false
         if not slotData.metadata?.radioId then
             id = SetRadioData(source, slotid)
         else


### PR DESCRIPTION
## Description

It fixes the variable scope for ID assignment, so it's accessible to the return statement.

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
