### PR TITLE
fix: stop jammer placement when permission check fails

### DIFF
--- a/client/event.lua
+++ b/client/event.lua
@@ -51,7 +51,7 @@ end)
 
 RegisterNetEvent('mm_radio:client:usejammer', function()
     if not Shared.Jammer.permission or not (lib.table.contains(Shared.Jammer.permission, Radio.PlayerJob) or lib.table.contains(Shared.Jammer.permission, Radio.PlayerGang)) then
-        lib.notify({
+        return lib.notify({
             title = 'You dont have permission to use this item',
             type = 'error'
         })


### PR DESCRIPTION
## Description

This PR fixes a bug where unauthorized players could still place a radio jammer. The permission check event in `client/event.lua` was missing a `return` statement, meaning that players without the required job or gang credentials would see the "You don't have permission" notification but the jammer would still successfully spawn.

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change

## Testing

Verified that the event handler exits execution immediately upon entering the authorization conditional block, blocking the spawning of the jammer object.

## Checklist

- [x] I tested this on a local Qbox server
- [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] My changes follow the [contribution guidelines](https://github.com/Qbox-project/.github/blob/main/.github/contributing.md)
- [x] I fixed any lint issues reported by CI
