### PR TITLE
fix: secure server radio events

### DIFF
--- a/client/event.lua
+++ b/client/event.lua
@@ -240,9 +240,12 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
 end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
-    local player = QBX.PlayerData
-    player.job = job
-    Radio:Init(player)
+    Radio:Init({
+        cid = QBX.PlayerData.cid,
+        job = job,
+        gang = QBX.PlayerData.gang,
+        charinfo = QBX.PlayerData.charinfo
+    })
 end)
 
 RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
@@ -257,9 +260,12 @@ RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
 end)
 
 RegisterNetEvent('QBCore:Client:OnGangUpdate', function(gang)
-    local player = QBX.PlayerData
-    player.gang = gang
-    Radio:Init(player)
+    Radio:Init({
+        cid = QBX.PlayerData.cid,
+        job = QBX.PlayerData.job,
+        gang = gang,
+        charinfo = QBX.PlayerData.charinfo
+    })
 end)
 
 RegisterNetEvent("QBCore:Client:SetDuty", function(newDuty)

--- a/client/function.lua
+++ b/client/function.lua
@@ -188,13 +188,11 @@ function Radio:CalculateTimeToDisplay()
     local minute = GetClockMinutes()
     local second = GetClockSeconds()
 
-    local obj = ""
-
 	if minute <= 9 then
 		minute = "0" .. minute
     end
 
-    obj = hour..":"..minute
+    local obj = hour..":"..minute
 
     return obj, (60 - second)
 end

--- a/client/nui.lua
+++ b/client/nui.lua
@@ -118,7 +118,7 @@ end)
 RegisterNUICallback('saveData', function(data, cb)
     local player = QBX.PlayerData
     local identifier = player.cid
-    if not identifier then return Radio:Notify(locale('unsuccess_name', channel)) end
+    if not identifier then return Radio:Notify(locale('unsuccess_name')) end
     Radio.userData[Radio.identifier].name = data.name
     Radio:update()
     TriggerServerEvent('mm_radio:server:addToRadioChannel', Radio.RadioChannel, data.name)

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,11 +1,161 @@
 local channels = {}
 local jammer = {}
 local batteryData = {}
+local currentChannel = {}
+local batteryCooldown = {}
+local radioCooldown = {}
 local spawnedDefaultJammer = false
+local nextJammerId = 0
 
-RegisterNetEvent('mm_radio:server:consumeBattery', function(data)
-    for i=1, #data do
-        local id = data[i]
+local function isFiniteNumber(value)
+    return type(value) == 'number' and value == value and value > -math.huge and value < math.huge
+end
+
+local function getPlayerRadioIds(source)
+    local radioIds = {}
+
+    for i = 1, #Shared.RadioItem do
+        local slots = exports.ox_inventory:GetSlotsWithItem(source, Shared.RadioItem[i])
+        for _, item in pairs(slots or {}) do
+            local radioId = item.metadata?.radioId
+            if radioId then radioIds[radioId] = true end
+        end
+    end
+
+    return radioIds
+end
+
+local function hasRadio(source)
+    for i = 1, #Shared.RadioItem do
+        local slot = exports.ox_inventory:GetSlotIdWithItem(source, Shared.RadioItem[i])
+        if slot then return true end
+    end
+
+    return false
+end
+
+local function removePlayerFromRadioChannel(source)
+    local channel = currentChannel[source]
+    if not channel or not channels[channel] then return end
+
+    channels[channel][tostring(source)] = nil
+    currentChannel[source] = nil
+    TriggerClientEvent('mm_radio:client:radioListUpdate', -1, channels[channel], channel)
+    if not next(channels[channel]) then channels[channel] = nil end
+end
+
+local function checkCooldown(cooldowns, source, duration)
+    local time = os.time()
+    if cooldowns[source] and cooldowns[source] > time then return false end
+
+    cooldowns[source] = time + duration
+    return true
+end
+
+local function hasChannelPermission(player, channel)
+    local restriction = Shared.RestrictedChannels[channel]
+    if not restriction then return true end
+
+    local group = player.PlayerData[restriction.type]
+    return group and lib.table.contains(restriction.name, group.name)
+end
+
+local function hasJammerPermission(source)
+    local player = exports.qbx_core:GetPlayer(source)
+    if not player or not Shared.Jammer.permission then return false end
+
+    local job = player.PlayerData.job
+    local gang = player.PlayerData.gang
+    return job and lib.table.contains(Shared.Jammer.permission, job.name)
+        or gang and lib.table.contains(Shared.Jammer.permission, gang.name)
+end
+
+local function sanitizeAllowedChannels(allowedChannels)
+    local sanitized = {}
+    local seen = {}
+    if type(allowedChannels) ~= 'table' then return sanitized end
+
+    for i = 1, math.min(#allowedChannels, 32) do
+        local channel = allowedChannels[i]
+        if isFiniteNumber(channel) and channel > 0 and channel <= Shared.MaxFrequency and not seen[channel] then
+            sanitized[#sanitized + 1] = channel
+            seen[channel] = true
+        end
+    end
+
+    return sanitized
+end
+
+local function getJammer(id)
+    for i = 1, #jammer do
+        if jammer[i].id == id then return jammer[i], i end
+    end
+end
+
+local function isNearJammer(source, entity)
+    local ped = GetPlayerPed(source)
+    if ped == 0 then return false end
+
+    return #(GetEntityCoords(ped) - vec3(entity.coords.x, entity.coords.y, entity.coords.z)) <= 3.0
+end
+
+local function getNextJammerId()
+    local id
+    repeat
+        nextJammerId += 1
+        id = ('placed:%d'):format(nextJammerId)
+    until not getJammer(id)
+
+    return id
+end
+
+local function createJammer(data, source)
+    CreateThread(function()
+        local entity = CreateObject(joaat(Shared.Jammer.model), data.coords.x, data.coords.y, data.coords.z, true, true, false)
+        local attempts = 0
+        while not DoesEntityExist(entity) and attempts < 100 do
+            attempts += 1
+            Wait(50)
+        end
+
+        if not DoesEntityExist(entity) then
+            if source then exports.ox_inventory:AddItem(source, 'jammer', 1) end
+            return
+        end
+
+        SetEntityHeading(entity, data.coords.w)
+        local netobj = NetworkGetNetworkIdFromEntity(entity)
+        local jammerData = {
+            enable = true,
+            entity = entity,
+            id = data.id,
+            coords = data.coords,
+            range = data.range,
+            allowedChannels = data.allowedChannels,
+            canRemove = data.canRemove,
+            canDamage = data.canDamage
+        }
+
+        jammer[#jammer + 1] = jammerData
+        TriggerClientEvent('mm_radio:client:syncobject', -1, {
+            enable = jammerData.enable,
+            object = netobj,
+            coords = jammerData.coords,
+            id = jammerData.id,
+            range = jammerData.range,
+            allowedChannels = jammerData.allowedChannels,
+            canRemove = jammerData.canRemove,
+            canDamage = jammerData.canDamage
+        })
+    end)
+end
+
+RegisterNetEvent('mm_radio:server:consumeBattery', function()
+    if not Shared.Battery.state then return end
+    if not checkCooldown(batteryCooldown, source, math.max(math.floor(Shared.Battery.depletionTime * 60), 1)) then return end
+
+    local radioIds = getPlayerRadioIds(source)
+    for id in pairs(radioIds) do
         if not batteryData[id] then batteryData[id] = 100 end
         local battery = batteryData[id] - Shared.Battery.consume
         batteryData[id] = math.max(battery, 0)
@@ -16,14 +166,16 @@ RegisterNetEvent('mm_radio:server:consumeBattery', function(data)
 end)
 
 RegisterNetEvent('mm_radio:server:rechargeBattery', function()
+    if not Shared.Battery.state then return end
+
     local src = source
     for i=1, #Shared.RadioItem do
         local item = exports.ox_inventory:GetSlotWithItem(src, Shared.RadioItem[i])
         if item then
             local id = item.metadata?.radioId or false
             if not id then return end
+            if not exports.ox_inventory:RemoveItem(src, 'radiocell', 1) then return end
             batteryData[id] = 100
-            exports.ox_inventory:RemoveItem(src, 'radiocell', 1)
             break
         end
     end
@@ -31,114 +183,99 @@ end)
 
 RegisterNetEvent('mm_radio:server:spawnobject', function(data)
     local src = source
-	CreateThread(function()
-		local entity = CreateObject(joaat(Shared.Jammer.model), data.coords.x, data.coords.y, data.coords.z, true, true, false)
-		while not DoesEntityExist(entity) do Wait(50) end
-		SetEntityHeading(entity, data.coords.w)
-        local netobj = NetworkGetNetworkIdFromEntity(entity)
-        if data.canRemove then
-            exports.ox_inventory:RemoveItem(src, 'jammer', 1)
-        end
-        TriggerClientEvent('mm_radio:client:syncobject', -1, {
-            enable = true,
-            object = netobj,
-            coords = data.coords,
-            id = data.id,
-            range = data.range or Shared.Jammer.range.default,
-            allowedChannels = data.allowedChannels or {},
-            canRemove = data.canRemove,
-            canDamage = data.canDamage
-        })
-        jammer[#jammer+1] = {
-            enable = true,
-            entity = entity,
-            id = data.id,
-            coords = data.coords,
-            range = data.range or Shared.Jammer.range.default,
-            allowedChannels = data.allowedChannels or {},
-            canRemove = data.canRemove,
-            canDamage = data.canDamage
-        }
-	end)
+    if type(data) ~= 'table' or not hasJammerPermission(src) then return end
+
+    local coords = data.coords
+    local coordsType = type(coords)
+    if coordsType ~= 'table' and coordsType ~= 'vector4' then return end
+    if not isFiniteNumber(coords.x) or not isFiniteNumber(coords.y)
+        or not isFiniteNumber(coords.z) or not isFiniteNumber(coords.w) then return end
+
+    local ped = GetPlayerPed(src)
+    if ped == 0 or #(GetEntityCoords(ped) - vec3(coords.x, coords.y, coords.z)) > 3.0 then return end
+    if not exports.ox_inventory:RemoveItem(src, 'jammer', 1) then return end
+
+    createJammer({
+        coords = vec4(coords.x, coords.y, coords.z, coords.w),
+        id = getNextJammerId(),
+        range = Shared.Jammer.range.default,
+        allowedChannels = {},
+        canRemove = true,
+        canDamage = true
+    }, src)
 end)
 
 RegisterNetEvent('mm_radio:server:togglejammer', function(id)
-    for i=1, #jammer do
-        local entity = jammer[i]
-        if entity.id == id then
-            jammer[i].enable = not jammer[i].enable
-            TriggerClientEvent('mm_radio:client:togglejammer', -1, id, jammer[i].enable)
-            break
-        end
-    end
+    local entity = getJammer(id)
+    if not entity or not isNearJammer(source, entity) then return end
+
+    entity.enable = not entity.enable
+    TriggerClientEvent('mm_radio:client:togglejammer', -1, id, entity.enable)
 end)
 
-RegisterNetEvent('mm_radio:server:removejammer', function(id, isDamaged)
+RegisterNetEvent('mm_radio:server:removejammer', function(id)
     local src = source
-	CreateThread(function()
-        for i=1, #jammer do
-            local entity = jammer[i]
-            if entity.id == id then
-                DeleteEntity(entity.entity)
-                TriggerClientEvent('mm_radio:client:removejammer', -1, id)
-                table.remove(jammer, i)
-                if not isDamaged then
-                    exports.ox_inventory:AddItem(src, 'jammer', 1)
-                end
-                break
-            end
-        end
-	end)
+    local entity, index = getJammer(id)
+    if not entity or not entity.canRemove or not isNearJammer(src, entity) then return end
+
+    local shouldRefund = GetEntityHealth(entity.entity) > 0
+    DeleteEntity(entity.entity)
+    TriggerClientEvent('mm_radio:client:removejammer', -1, id)
+    table.remove(jammer, index)
+    if shouldRefund then exports.ox_inventory:AddItem(src, 'jammer', 1) end
 end)
 
 RegisterNetEvent('mm_radio:server:changeJammerRange', function(id, range)
-    for i=1, #jammer do
-        local entity = jammer[i]
-        if entity.id == id then
-            jammer[i].range = range
-            TriggerClientEvent('mm_radio:client:changeJammerRange', -1, id, range)
-            break
-        end
-    end
+    local entity = getJammer(id)
+    if not entity or not isNearJammer(source, entity) or not isFiniteNumber(range) then return end
+
+    entity.range = math.min(math.max(range, Shared.Jammer.range.min), Shared.Jammer.range.max)
+    TriggerClientEvent('mm_radio:client:changeJammerRange', -1, id, entity.range)
 end)
 
 RegisterNetEvent('mm_radio:server:removeallowedchannel', function(id, allowedChannels)
-    for i=1, #jammer do
-        local entity = jammer[i]
-        if entity.id == id then
-            jammer[i].allowedChannels = allowedChannels
-            TriggerClientEvent('mm_radio:client:removeallowedchannel', -1, id, allowedChannels)
-            break
-        end
-    end
+    local entity = getJammer(id)
+    if not entity or not isNearJammer(source, entity) then return end
+
+    entity.allowedChannels = sanitizeAllowedChannels(allowedChannels)
+    TriggerClientEvent('mm_radio:client:removeallowedchannel', -1, id, entity.allowedChannels)
 end)
 
 RegisterNetEvent('mm_radio:server:addallowedchannel', function(id, allowedChannels)
-    for i=1, #jammer do
-        local entity = jammer[i]
-        if entity.id == id then
-            jammer[i].allowedChannels = allowedChannels
-            TriggerClientEvent('mm_radio:client:addallowedchannel', -1, id, allowedChannels)
-            break
-        end
-    end
+    local entity = getJammer(id)
+    if not entity or not isNearJammer(source, entity) then return end
+
+    entity.allowedChannels = sanitizeAllowedChannels(allowedChannels)
+    TriggerClientEvent('mm_radio:client:addallowedchannel', -1, id, entity.allowedChannels)
 end)
 
-RegisterNetEvent('mm_radio:server:addToRadioChannel', function(channel, username)
+RegisterNetEvent('mm_radio:server:addToRadioChannel', function(channel)
     local src = source
+    if not isFiniteNumber(channel) or channel <= 0 or channel > Shared.MaxFrequency then return end
+
+    local normalizedChannel = math.floor(channel * 100 + 0.5) / 100
+    if math.abs(channel - normalizedChannel) > 0.00001 or not checkCooldown(radioCooldown, src, 1) then return end
+    channel = normalizedChannel
+
+    local player = exports.qbx_core:GetPlayer(src)
+    if not player or not hasRadio(src) or not hasChannelPermission(player, channel) then return end
+
+    removePlayerFromRadioChannel(src)
     if not channels[channel] then
         channels[channel] = {}
     end
-    channels[channel][tostring(src)] = {name = username, isTalking = false}
+
+    local charinfo = player.PlayerData.charinfo
+    channels[channel][tostring(src)] = {
+        name = ('%s %s'):format(charinfo.firstname, charinfo.lastname),
+        isTalking = false
+    }
+    currentChannel[src] = channel
     TriggerClientEvent('mm_radio:client:radioListUpdate', -1, channels[channel], channel)
 end)
 
-RegisterNetEvent('mm_radio:server:removeFromRadioChannel', function(channel)
-    local src = source
-
-    if not channels[channel] then return end
-    channels[channel][tostring(src)] = nil
-    TriggerClientEvent('mm_radio:client:radioListUpdate', -1, channels[channel], channel)
+RegisterNetEvent('mm_radio:server:removeFromRadioChannel', function()
+    removePlayerFromRadioChannel(source)
 end)
 
 AddEventHandler('onResourceStop', function(resourceName)
@@ -156,25 +293,20 @@ AddEventHandler('onResourceStart', function(resourceName)
 end)
 
 AddEventHandler("playerDropped", function()
-    local plyid = source
-    for id, channel in pairs (channels) do
-        if channel[tostring(plyid)] then
-            channels[id][tostring(plyid)] = nil
-            TriggerClientEvent('mm_radio:client:radioListUpdate', -1, channels[id], id)
-            break
-        end
-    end
+    removePlayerFromRadioChannel(source)
+    batteryCooldown[source] = nil
+    radioCooldown[source] = nil
 end)
 
 RegisterNetEvent("mm_radio:server:createdefaultjammer", function()
     if spawnedDefaultJammer then return end
     for i=1, #Shared.Jammer.default do
         local data = Shared.Jammer.default[i]
-        TriggerEvent('mm_radio:server:spawnobject', {
+        createJammer({
             coords = data.coords,
             id = data.id,
-            range = data.range,
-            allowedChannels = data.allowedChannels,
+            range = math.min(math.max(data.range or Shared.Jammer.range.default, Shared.Jammer.range.min), Shared.Jammer.range.max),
+            allowedChannels = sanitizeAllowedChannels(data.allowedChannels),
             canRemove = false,
             canDamage = data.canDamage
         })
@@ -184,6 +316,8 @@ end)
 
 local function SetRadioData(src, slot)
     local player = exports.qbx_core:GetPlayer(src)
+    if not player then return end
+
     local radioId = player.PlayerData.citizenid .. math.random(1000, 9999)
     local name = player.PlayerData.charinfo.firstname .. " " .. player.PlayerData.charinfo.lastname
     exports.ox_inventory:SetMetadata(src, slot, { radioId = radioId, name = name })

--- a/server/main.lua
+++ b/server/main.lua
@@ -326,14 +326,16 @@ end
 
 local function GetSlotWithRadio(source)
     for i=1, #Shared.RadioItem do
-        return exports.ox_inventory:GetSlotIdWithItem(source, Shared.RadioItem[i])
+        local slot = exports.ox_inventory:GetSlotIdWithItem(source, Shared.RadioItem[i])
+        if slot then return slot end
     end
 end
 
 lib.callback.register('mm_radio:server:getradiodata', function(source, slot)
     if not Shared.Battery.state then return 100, 'PERSONAL' end
     local battery = 100
-    local slotid = false
+    local id = false
+    local slotid
     if not slot then
         slotid = GetSlotWithRadio(source)
     else
@@ -341,7 +343,6 @@ lib.callback.register('mm_radio:server:getradiodata', function(source, slot)
     end
     local slotData = exports.ox_inventory:GetSlot(source, slotid)
     if slotData and lib.table.contains(Shared.RadioItem, slotData.name) then
-        local id = false
         if not slotData.metadata?.radioId then
             id = SetRadioData(source, slotid)
         else


### PR DESCRIPTION
## What changed

- validate jammer placement permissions, coordinates, proximity, and inventory removal on the server
- generate jammer identifiers and enforce server-owned range, channel, removability, and damage settings
- require proximity for jammer mutation/removal and derive damage state from the entity before refunding an item
- consume batteries only for radio IDs currently in the caller's inventory, rate-limited to the configured depletion interval
- require a radio and restricted-channel membership before adding a player to the radio list
- derive radio-list names from server player data and clean up empty channels
- bound and rate-limit channel changes and sanitize jammer channel lists
- only recharge after successfully consuming a radio cell

## Why

Several client-reachable events trusted identifiers, flags, coordinates, and inventory outcomes supplied by the caller. A modified client could create or refund jammer items without paying for them, mutate jammers remotely, recharge without a cell, drain arbitrary stored radio IDs, and grow or spoof the radio-list state.

The server now owns those decisions while preserving the existing client event API.

## Validation

- `git diff --check`
- direct Lua control-flow and syntax review (no Lua runtime/linter is installed locally)
- GitHub lint workflow will validate the pushed Lua change

Drafted for maintainer review because the jammer and battery features are disabled in the default configuration.